### PR TITLE
fix: tailwind 겹치는 커스텀 이미지명 변경

### DIFF
--- a/src/components/homes/notices/NoticeHeader.tsx
+++ b/src/components/homes/notices/NoticeHeader.tsx
@@ -17,7 +17,7 @@ const NoticeHeader: React.FC = () => {
   return (
     <div className="flex flex-row w-full h-[48px] text-secondary-700 bg-white justify-center items-center font-medium text-xl relative">
       <div
-        className="w-[18px] h-[17px] bg-arrow-back bg-cover bg-no-repeat absolute left-[24px] cursor-pointer"
+        className="w-[18px] h-[17px] bg-arrow-back-black bg-cover bg-no-repeat absolute left-[24px] cursor-pointer"
         onClick={handleClickBackArrow}
       ></div>
       <div>공지사항</div>

--- a/src/pages/mains/BoothDetailPage.tsx
+++ b/src/pages/mains/BoothDetailPage.tsx
@@ -51,7 +51,7 @@ const BoothDetailPage: React.FC = () => {
         <div className="w-full h-[220px] xs:h-[255px] sm:h-[295px] bg-booth-detail-banner bg-cover">
           <div
             onClick={handleClickBoothDetailBack}
-            className="z-4 bg-arrow-back w-6 h-6 bg-no-repeat text-xl absolute top-[24px] left-[24px] bg-cover pointer-events-auto cursor-pointer"
+            className="z-4 bg-arrow-back-white w-6 h-6 bg-no-repeat text-xl absolute top-[24px] left-[24px] bg-cover pointer-events-auto cursor-pointer"
           />
           {/* 슬로건 + 운영진 */}
           <div className="absolute w-auto h-auto dynamic-top dynamic-padding">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -104,13 +104,13 @@ export default {
         'slide-banner-3': "url('/images/homes/slide-banner-3.svg')",
         'angle-bracket': "url('/icons/homes/angle-bracket.svg')",
         'talent-icon': "url('/icons/homes/talent.svg')",
-        'arrow-back': "url('/icons/homes/arrow-back.svg')",
+        'arrow-back-black': "url('/icons/homes/arrow-back.svg')",
         'pin-icon': "url('icons/homes/pin.svg')",
         // booth
         'booth-banner': "url('/images/booths/banners/booth.svg')",
         'booth-detail-banner': "url('/images/booths/banners/booth-detail.svg')",
         'default': "url('/images/booths/default.svg')",
-        'arrow-back': "url('/icons/booths/arrow-back.svg')",
+        'arrow-back-white': "url('/icons/booths/arrow-back.svg')",
         'arrow-forward': "url('/icons/booths/arrow-forward.svg')",
         'reservation-status': "url('/images/booths/reserve.svg')"
       },


### PR DESCRIPTION
## 📄 설명
- tailwind에서 커스텀해서 사용하는 공지사항의 뒤로가기 버튼과 부스 상세페이지의 뒤로가기 아이콘명이 겹쳐서 안 뜨는 현상 발생

## 📸 이미지/동영상
- 변경사항/작업결과 이미지/동영상을 추가해 주세요.

## ✅ 체크사항
- [x] 아이콘 이름 변경

## 📢 기타(선택)
